### PR TITLE
Rename tags methods in MailchimpLists

### DIFF
--- a/src/MailchimpLists.php
+++ b/src/MailchimpLists.php
@@ -503,9 +503,9 @@ class MailchimpLists extends Mailchimp {
    *
    * @return object
    *
-   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/#create-post_lists_list_id_members_subscriber_hash_tags
    */
-  public function addTagsMember($list_id, array $tags, $email, array $parameters = []) {
+  public function addMemberTags($list_id, array $tags, $email, array $parameters = []) {
     $tokens = [
       'list_id' => $list_id,
       'subscriber_hash' => md5(strtolower($email)),
@@ -535,9 +535,9 @@ class MailchimpLists extends Mailchimp {
    *
    * @return object
    *
-   * @see https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/
+   * @see http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/#create-post_lists_list_id_members_subscriber_hash_tags
    */
-  public function removeTagsMember($list_id, array $tags, $email, array $parameters = []) {
+  public function removeMemberTags($list_id, array $tags, $email, array $parameters = []) {
     $tokens = [
       'list_id' => $list_id,
       'subscriber_hash' => md5(strtolower($email)),

--- a/tests/MailchimpListsTest.php
+++ b/tests/MailchimpListsTest.php
@@ -304,12 +304,13 @@ class MailchimpListsTest extends TestCase {
   /**
    * Tests library functionality for adding tags to a member.
    */
-  public function testAddTagsMember() {
+  public function testAddMemberTags() {
     $list_id = '205d96e6b4';
     $tags = ['Foo', 'Bar'];
     $email = 'test@example.com';
+
     $mc = new MailchimpLists();
-    $mc->addTagsMember($list_id, $tags, $email);
+    $mc->addMemberTags($list_id, $tags, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);
     $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members/' . md5($email) . '/tags', $mc->getClient()->uri);
@@ -334,12 +335,13 @@ class MailchimpListsTest extends TestCase {
   /**
    * Tests library functionality for removing tags from a member.
    */
-  public function testRemoveTagsMember() {
+  public function testRemoveMemberTags() {
     $list_id = '205d96e6b4';
     $tags = ['Foo', 'Bar'];
     $email = 'test@example.com';
+
     $mc = new MailchimpLists();
-    $mc->removeTagsMember($list_id, $tags, $email);
+    $mc->removeMemberTags($list_id, $tags, $email);
 
     $this->assertEquals('POST', $mc->getClient()->method);
     $this->assertEquals($mc->getEndpoint() . '/lists/' . $list_id . '/members/' . md5($email) . '/tags', $mc->getClient()->uri);


### PR DESCRIPTION
@MegaChriz Thank you for [adding the methods of adding/removing tags](https://github.com/thinkshout/mailchimp-api-php/pull/76). They are very useful. Could you consider renaming the two methods to follow the naming convention in MailchimpLists? Thanks!
`addTagsMember`        ->  `addMemberTags`
`removeTagsMember`  ->  `removeMemberTags`

Btw, I created a PR to add getMemberTags method https://github.com/thinkshout/mailchimp-api-php/pull/84.

